### PR TITLE
feat(settings): added deviation setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Settings are located in [settings.json](https://github.com/drknzz/auto-lingo/blo
 
 * `chromedriver_path` &emsp; - Path to chromedriver executable
 * `antifarm_sleep` &emsp;&emsp;&thinsp;&thinsp; - Sleep time inbetween completing stories / skills
+* `deviation` &emsp;&emsp;&thinsp;&thinsp; - Deviation of antifarm_sleep time for harder bot detection
 * `maximize_window` &emsp;&emsp; - Start browser in full screen
 * `headless` &emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp;&thinsp; - No browser gui required
 * `incognito` &emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;&thinsp;&thinsp; - Start browser in incognito mode

--- a/auto-lingo.py
+++ b/auto-lingo.py
@@ -1,4 +1,4 @@
-import sys, time, json, argparse
+import sys, time, json, argparse, random
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -43,6 +43,14 @@ def get_settings():
             settings = json.load(json_f)
     except:
         print("Failed to import settings from settings.json.")
+        sys.exit()
+        
+    if settings['deviation'] > settings['antifarm_sleep'] and settings['antifarm_sleep'] != 0:
+        print("deviation cannot be larger than antifarm_sleep time")
+        sys.exit()
+        
+    if settings['deviation'] < 0:
+        print("deviation cannot be negative")
         sys.exit()
 
     return settings
@@ -621,7 +629,9 @@ def stories_bot():
             complete_story()
 
             if settings['antifarm_sleep'] > 0:
-                time.sleep(settings['antifarm_sleep'])
+                deviation = random.randint(-settings['deviation'], settings['deviation'])
+                print(deviation)
+                time.sleep(settings['antifarm_sleep'] + deviation)
 
 
 def learn_bot():
@@ -694,7 +704,8 @@ def learn_bot():
             completed_skill = True
 
             if settings['antifarm_sleep'] > 0:
-                time.sleep(settings['antifarm_sleep'])
+                deviation = random.randint(-settings['deviation'], settings['deviation'])
+                time.sleep(settings['antifarm_sleep'] + deviation)
 
             break
 

--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,9 @@
 {
     "chromedriver_path": "C:\\Program Files (x86)\\chromedriver.exe",
 
-    "antifarm_sleep": 0,
+    "antifarm_sleep": 10,
+
+    "deviation": 0,
 
     "maximize_window": true,
 
@@ -12,5 +14,4 @@
     "auto_login": false,
 
     "mute_audio": true
-
 }


### PR DESCRIPTION
Deviation setting is used to replace the constant value of waiting in between challenges to a range of time [antifarm_sleep - deviation, antifarm_sleep + deviation]. Deviation is ignored if antifarm_sleep is 0 and is incorrect if it's value is bigger than antifarm_sleep or it's value is negative